### PR TITLE
fix the error "Class "FriendsOfHyperf\Support\RedisCommand" not found "

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "pull-request": "https://github.com/friendsofhyperf/components/pulls"
     },
     "require": {
+        "friendsofhyperf/support": "~3.1.61",
         "hyperf/command": "~3.1.0",
         "hyperf/context": "~3.1.0",
         "hyperf/coroutine": "~3.1.0",


### PR DESCRIPTION
Class "FriendsOfHyperf\Support\RedisCommand" not found in vendor/friendsofhyperf/sentry/src/Tracing/Aspect/RedisAspect.php:69

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new dependency on the `friendsofhyperf/support` package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->